### PR TITLE
Fix typo in dumb-init path and pin upstream vault image tag. Fixes #7.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM vault:latest
+FROM vault:1.3.0
 
 ADD . /tmp/
 

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/dumb-init /bin/sh
+#!/usr/bin/dumb-init /bin/sh
 
 rm -f /opt/healthcheck
 


### PR DESCRIPTION
Fixes typo in dumb-init path (not sure how that made it in-- thanks @d-rep) and pin upstream Vault image while we are at it.

Fixes #7.
